### PR TITLE
Patches deprecated syntax of sha256

### DIFF
--- a/Formula/awless.rb
+++ b/Formula/awless.rb
@@ -9,8 +9,7 @@ class Awless < Formula
 
   bottle do
     root_url "https://github.com/wallix/homebrew-awless/releases/download/#{version}"
-    cellar :any_skip_relocation
-    sha256 "dbd1e5f4afd1de6fe00372bd8b6fffa9a448bbf461019094a5061b1b96924096" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "dbd1e5f4afd1de6fe00372bd8b6fffa9a448bbf461019094a5061b1b96924096"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
This commit patches deprecated syntax of homebrew of `sha256`.

Hi, I accidentally found the warning message while updating `awless`.

Here below is the detail of the warning message I got.

```
Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
```